### PR TITLE
Switch datatype of 'output_bed' from 'bed' to 'pbed'

### DIFF
--- a/snp2hla-p.xml
+++ b/snp2hla-p.xml
@@ -62,7 +62,7 @@
   </inputs>
   <outputs>
     <data name="output_bim" format="tabular" label="SNP2HLA on ${on_string}: BIM file" />
-    <data name="output_bed" format="bed" label="SNP2HLA on ${on_string}: BED file" />
+    <data name="output_bed" format="pbed" label="SNP2HLA on ${on_string}: PLINK BED file" />
     <data name="output_fam" format="txt" label="SNP2HLA on ${on_string}: FAM file" />
     <data name="output_r2" format="tabular" label="SNP2HLA on ${on_string}: r2 file" />
     <data name="output_log" format="txt" label="SNP2HLA on ${on_string}: LOG file" />


### PR DESCRIPTION
PR which changes the datatype of the `output_bed` dataset from `bed` (UCSC tabular BED format) to `pbed` (PLINK binary BED format).

For Galaxy 18.05, running without this change appears to cause an error trying to set the metadata on the `output_bed` dataset because it can't be parsed by Galaxy's internals - it produces an error of the form:

    Traceback (most recent call last):
      File "lib/galaxy/jobs/runners/jse_drop_runner.py", line 372, in finish_job
        job_state.job_wrapper.finish(stdout,stderr,exit_code)
      File "lib/galaxy/jobs/__init__.py", line 1301, in finish
        dataset.datatype.set_meta(dataset, overwrite=False)
      File "lib/galaxy/datatypes/interval.py", line 426, in set_meta
        Tabular.set_meta(self, dataset, overwrite=overwrite, skip=i)
      File "lib/galaxy/datatypes/tabular.py", line 337, in set_meta
        line = dataset_fh.readline()
      File "/XXXXXXXXXXXXXXXXXXXXXXXXXX/galaxy-dist/.venv/lib/python2.7/codecs.py", line 296, in decode
        (result, consumed) = self._buffer_decode(data, self.errors, final)
    UnicodeDecodeError: 'utf8' codec can't decode byte 0xab in position 3: invalid start byte

Details of PLINK's BED format are described here:

* PLINK `--make-bed` option: https://www.cog-genomics.org/plink/1.9/data
* PLINK binary biallelic genotype table (i.e. PLINK BED): https://www.cog-genomics.org/plink/1.9/formats#bed

To quote from the second document:

> Do not confuse this with the UCSC Genome Browser's BED format, which is totally different.
